### PR TITLE
add email module to nytta

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To read more about the nytta helpers visit the different readme files of the mod
 * [Spring Extensions](spring-ext/README.md)
 * [iHop](ihop/README.md)
 * [Tracking](tracking/README.md)
+* [E-Mail](email/README.md)
+* [Spring E-Mail](spring-email/README.md)
 
 ## Development
 

--- a/email/core/.gitignore
+++ b/email/core/.gitignore
@@ -5,15 +5,9 @@
 /classes/
 /gradle/
 
-# Maven
-target
-release.properties
-pom.xml.releaseBackup
-
 # IntelliJ IDEA project configuration
-*.iml
-*/.idea/*
-.idea/*
+/*.iml
+/.idea/*
 
 # macOS
 .DS_Store

--- a/email/core/pom.xml
+++ b/email/core/pom.xml
@@ -3,30 +3,30 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.timeular.nytta</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>com.timeular.nytta.email</groupId>
+        <artifactId>email-parent</artifactId>
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.timeular.nytta</groupId>
-    <artifactId>http-client</artifactId>
+    <groupId>com.timeular.nytta.email</groupId>
+    <artifactId>core</artifactId>
     <version>2.2.0-SNAPSHOT</version>
 
-    <name>Timeular Nytta Http Client</name>
-    <description>This is a helper module to provide a simple http client.</description>
-    <url>https://github.com/Timeular/nytta/http-client</url>
+    <name>Timeular Nytta Email</name>
+    <description>This module provides basic infrastructure for sending email</description>
+    <url>https://github.com/Timeular/nytta/email/core</url>
 
     <dependencies>
         <dependency>
-            <groupId>com.github.salomonbrys.kotson</groupId>
-            <artifactId>kotson</artifactId>
-            <version>2.5.0</version>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.0.11.RELEASE</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-            <version>1.2.4.RELEASE</version>
-            <optional>true</optional>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.197</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -41,9 +41,16 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
+            <groupId>org.dbunit</groupId>
+            <artifactId>dbunit</artifactId>
+            <version>2.5.4</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/AbstractMailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/AbstractMailService.kt
@@ -1,0 +1,44 @@
+package com.timeular.nytta.email.core
+
+import java.time.ZonedDateTime
+
+abstract class AbstractMailService(
+        private val mailTemplateContentBuilder: MailTemplateContentBuilder,
+        private val mailServiceHelper: MailServiceHelper
+) : MailService {
+
+    override fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>,
+            deliveryTime: ZonedDateTime?,
+            inlineAttachments: List<Attachment>
+    ): Boolean {
+
+        var mailCfgBuilder = MailConfig.Builder.from(mailTemplate.mailConfigBuilder)
+
+        receiver.forEach {
+            mailCfgBuilder.addTo(it.email, it.name)
+        }
+
+        val correctedCtx = mailServiceHelper.modifyTemplateContextForOverride(mailContext, mailCfgBuilder)
+
+        mailCfgBuilder = mailServiceHelper.modifyMailConfigBuilderForOverride(mailCfgBuilder)
+
+        mailCfgBuilder.deliveryTime(deliveryTime)
+
+        mailTemplate.htmlTemplate?.run {
+            mailCfgBuilder.html(mailTemplateContentBuilder.build(mailTemplate.htmlTemplate, correctedCtx))
+        }
+
+        mailTemplate.txtTemplate?.run {
+            mailCfgBuilder.text(mailTemplateContentBuilder.build(mailTemplate.txtTemplate, correctedCtx))
+        }
+
+        inlineAttachments.forEach {
+            mailCfgBuilder.addInlineAttachment(it)
+        }
+
+        return sendMail(mailCfgBuilder.build())
+    }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/AsyncMailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/AsyncMailService.kt
@@ -1,0 +1,52 @@
+package com.timeular.nytta.email.core
+
+import org.slf4j.LoggerFactory
+import java.time.ZonedDateTime
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+class AsyncMailService @JvmOverloads constructor(
+        private val mailService: MailService,
+        private val executor: Executor = Executors.newFixedThreadPool(1)
+) : MailService {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AsyncMailService::class.java)
+    }
+
+    override fun sendMail(mailConfig: MailConfig): Boolean {
+        executor.run {
+            try {
+                mailService.sendMail(mailConfig)
+            } catch (ex: Throwable) {
+                logger.error("Unable to send email: `{}`", mailConfig.subject, ex)
+            }
+        }
+
+        return true
+    }
+
+    override fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>,
+            deliveryTime: ZonedDateTime?,
+            inlineAttachments: List<Attachment>
+    ): Boolean {
+        executor.run {
+            try {
+                mailService.sendMail(
+                        mailTemplate = mailTemplate,
+                        mailContext = mailContext,
+                        receiver = receiver,
+                        deliveryTime = deliveryTime,
+                        inlineAttachments = inlineAttachments
+                )
+            } catch (ex: Throwable) {
+                logger.error("Unable to send email: `{}`", mailTemplate.htmlTemplate, ex)
+            }
+        }
+
+        return true
+    }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/DbPersistentMailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/DbPersistentMailService.kt
@@ -1,0 +1,16 @@
+package com.timeular.nytta.email.core
+
+import com.timeular.nytta.email.core.db.MailStorageRepository
+
+/**
+ * this mail service stores the email inside a db instead of sending them
+ */
+open class DbPersistentMailService(
+        mailTemplateContentBuilder: MailTemplateContentBuilder,
+        private val mailStorageRepository: MailStorageRepository,
+        mailServiceHelper: MailServiceHelper
+) : AbstractMailService(mailTemplateContentBuilder, mailServiceHelper) {
+
+    override fun sendMail(mailConfig: MailConfig): Boolean =
+            mailStorageRepository.saveMailConfig(mailConfig)
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailConfig.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailConfig.kt
@@ -1,0 +1,204 @@
+package com.timeular.nytta.email.core
+
+import java.time.ZonedDateTime
+
+data class MailContact @JvmOverloads constructor(
+        val email: String,
+        val name: String? = null
+) {
+    override fun toString(): String =
+            name?.let { "$name <$email>" } ?: email
+}
+
+data class Attachment(
+        val name: String,
+        val mimeType: String,
+        val resource: ByteArray
+)
+
+class MailConfig private constructor(builder: Builder) {
+
+    companion object {
+        @JvmStatic
+        fun newBuilder() = Builder()
+    }
+
+    val from: MailContact
+    val subject: String
+    val to: List<MailContact>
+    val cc: List<MailContact>
+    val bcc: List<MailContact>
+    val text: String
+    val html: String
+    val deliveryTime: ZonedDateTime?
+    val tag: String?
+    val inlineAttachments: List<Attachment>
+
+    init {
+        from = builder.from as MailContact
+        subject = builder.subject
+        to = ArrayList(builder.to)
+        cc = ArrayList(builder.cc)
+        bcc = ArrayList(builder.bcc)
+        text = builder.text
+        html = builder.html
+        deliveryTime = builder.deliveryTime
+        tag = builder.tag
+        inlineAttachments = builder.inlineAttachments
+    }
+
+    class Builder {
+
+        companion object {
+            @JvmStatic
+            fun from(builder: Builder): Builder {
+                val newBuilder = Builder()
+                newBuilder.from = builder.from
+                newBuilder.subject = builder.subject
+                newBuilder.to += builder.to
+                newBuilder.cc += builder.cc
+                newBuilder.bcc += builder.bcc
+                newBuilder.text = builder.text
+                newBuilder.html = builder.html
+                newBuilder.deliveryTime = builder.deliveryTime
+                newBuilder.tag = builder.tag
+                newBuilder.inlineAttachments += builder.inlineAttachments
+
+                return newBuilder
+            }
+
+            @JvmStatic
+            fun from(mailCfg: MailConfig): Builder {
+                val builder = Builder()
+                builder.from = mailCfg.from
+                builder.subject = mailCfg.subject
+                builder.to += mailCfg.to
+                builder.cc += mailCfg.cc
+                builder.bcc += mailCfg.bcc
+                builder.text = mailCfg.text
+                builder.html = mailCfg.html
+                builder.deliveryTime = mailCfg.deliveryTime
+                builder.tag = mailCfg.tag
+                builder.inlineAttachments += mailCfg.inlineAttachments
+
+                return builder
+            }
+        }
+
+        internal var from: MailContact? = null
+        internal var subject: String = ""
+        internal var to: List<MailContact> = ArrayList()
+        internal var cc: List<MailContact> = ArrayList()
+        internal var bcc: List<MailContact> = ArrayList()
+        internal var text: String = ""
+        internal var html: String = ""
+        internal var inlineAttachments: List<Attachment> = ArrayList()
+        internal var deliveryTime: ZonedDateTime? = null
+        internal var tag: String? = null
+
+        fun from(mailContact: MailContact): Builder {
+            this.from = mailContact
+            return this
+        }
+
+        fun from(email: String, name: String? = null): Builder {
+            this.from = MailContact(email, name)
+            return this
+        }
+
+        fun subject(subject: String): Builder {
+            this.subject = subject
+            return this
+        }
+
+        fun addTo(email: String, name: String? = null): Builder {
+            this.to += MailContact(email, name)
+            return this
+        }
+
+        fun addCC(email: String, name: String? = null): Builder {
+            this.cc += MailContact(email, name)
+            return this
+        }
+
+        fun addBCC(email: String, name: String? = null): Builder {
+            this.bcc += MailContact(email, name)
+            return this
+        }
+
+        fun text(text: String): Builder {
+            this.text = text
+            return this
+        }
+
+        fun html(html: String): Builder {
+            this.html = html
+            return this
+        }
+
+        fun clearTo(): Builder {
+            this.to = ArrayList()
+            return this
+        }
+
+        fun clearCC(): Builder {
+            this.cc = ArrayList()
+            return this
+        }
+
+        fun clearBCC(): Builder {
+            this.bcc = ArrayList()
+            return this
+        }
+
+        fun tag(tag: String): Builder {
+            this.tag = tag
+            return this
+        }
+
+        fun deliveryTime(deliveryTime: ZonedDateTime?): Builder {
+            this.deliveryTime = deliveryTime
+            return this
+        }
+
+        fun addInlineAttachment(attachment: Attachment): Builder {
+            this.inlineAttachments += attachment
+            return this
+        }
+
+        fun addInlineAttachment(
+                name: String,
+                mimeType: String,
+                resource: ByteArray
+        ): Builder {
+            this.addInlineAttachment(Attachment(
+                    mimeType = mimeType,
+                    name = name,
+                    resource = resource
+            ))
+            return this
+        }
+
+        fun build(): MailConfig {
+            if (from == null)
+                throw MailConfigurationException("The From field is missing")
+
+            if (subject.isBlank())
+                throw MailConfigurationException("Subject is not allowed to be blank")
+
+            if (to.isEmpty() && cc.isEmpty() && bcc.isEmpty())
+                throw MailConfigurationException("You have to at least configure one of the following: TO, CC, BCC")
+
+            if (text.isBlank() && html.isBlank())
+                throw MailConfigurationException("Sending an email with an empty body is not supported at the moment")
+
+            return MailConfig(this)
+        }
+    }
+}
+
+data class MailTemplate @JvmOverloads constructor(
+        val mailConfigBuilder: MailConfig.Builder,
+        val htmlTemplate: String? = null,
+        val txtTemplate: String? = null
+)

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailException.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailException.kt
@@ -1,0 +1,5 @@
+package com.timeular.nytta.email.core
+
+open class MailException(msg: String): RuntimeException(msg)
+
+class MailConfigurationException(msg: String): MailException(msg)

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailService.kt
@@ -1,0 +1,53 @@
+package com.timeular.nytta.email.core
+
+import java.time.ZonedDateTime
+
+interface MailService {
+
+    fun sendMail(mailConfig: MailConfig): Boolean
+
+    fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>
+    ): Boolean = sendMail(
+            mailTemplate = mailTemplate,
+            mailContext = mailContext,
+            receiver = receiver,
+            deliveryTime = null
+    )
+
+    fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>,
+            deliveryTime: ZonedDateTime
+    ): Boolean = sendMail(
+            mailTemplate = mailTemplate,
+            mailContext = mailContext,
+            receiver = receiver,
+            deliveryTime = deliveryTime,
+            inlineAttachments = emptyList()
+    )
+
+    fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>,
+            inlineAttachments: List<Attachment> = emptyList()
+    ): Boolean = sendMail(
+            mailTemplate = mailTemplate,
+            mailContext = mailContext,
+            receiver = receiver,
+            inlineAttachments = inlineAttachments,
+            deliveryTime = null
+    )
+
+    fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>,
+            deliveryTime: ZonedDateTime? = null,
+            inlineAttachments: List<Attachment> = emptyList()
+    ): Boolean
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailServiceHelper.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailServiceHelper.kt
@@ -1,0 +1,65 @@
+package com.timeular.nytta.email.core
+
+import com.google.common.base.Joiner
+
+open class MailServiceHelper(
+        private val isOverrideEnabled: Boolean = false,
+        overrideAddressString: String = "invalid@timeular.com"
+) {
+
+    private var overrideAddress: MailContact = MailContact("invalid@timeular.com")
+
+    init {
+        overrideAddress = MailContact(overrideAddressString)
+    }
+
+    private val joiner = Joiner.on(",")
+
+    fun modifyTemplateContextForOverride(mailContext: Map<String, Any>, mailCfgBuilder: MailConfig.Builder): Map<String, Any> =
+            if (isOverrideEnabled) {
+                val resultMap = HashMap(mailContext)
+                resultMap["overrideAddress"] = overrideAddress.toString()
+                resultMap["originalAddressTo"] = joiner.join(mailCfgBuilder.to)
+                resultMap["originalAddressCC"] = joiner.join(mailCfgBuilder.cc)
+                resultMap["originalAddressBcc"] = joiner.join(mailCfgBuilder.bcc)
+
+                resultMap
+            } else {
+                mailContext
+            }
+
+    fun modifyMailConfigBuilderForOverride(mailCfgBuilder: MailConfig.Builder): MailConfig.Builder =
+            if (needToModifyMailConfigBuilder(mailCfgBuilder)) {
+                doModifyMailConfigBuilder(MailConfig.Builder.from(mailCfgBuilder))
+            } else {
+                mailCfgBuilder
+            }
+
+    fun modifyMailConfigForOverride(mailCfg: MailConfig): MailConfig =
+            if (needToModifyMailConfig(mailCfg)) {
+                doModifyMailConfigBuilder(MailConfig.Builder.from(mailCfg)).build()
+            } else {
+                mailCfg
+            }
+
+    internal fun needToModifyMailConfigBuilder(mailCfgBuilder: MailConfig.Builder): Boolean =
+            isOverrideEnabled &&
+                    (mailCfgBuilder.to.size > 1 || mailCfgBuilder.to.isEmpty() || mailCfgBuilder.to[0].email != overrideAddress.email
+                            || mailCfgBuilder.cc.isNotEmpty()
+                            || mailCfgBuilder.bcc.isNotEmpty())
+
+    internal fun needToModifyMailConfig(mailCfg: MailConfig): Boolean =
+            isOverrideEnabled &&
+                    (mailCfg.to.size > 1 || mailCfg.to.isEmpty() || mailCfg.to[0].email != overrideAddress.email
+                            || mailCfg.cc.isNotEmpty()
+                            || mailCfg.bcc.isNotEmpty())
+
+    private fun doModifyMailConfigBuilder(mailCfgBuilder: MailConfig.Builder): MailConfig.Builder {
+        mailCfgBuilder.clearBCC()
+        mailCfgBuilder.clearCC()
+        mailCfgBuilder.clearTo()
+        mailCfgBuilder.addTo(overrideAddress.email, overrideAddress.name)
+
+        return mailCfgBuilder
+    }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailTemplateContentBuilder.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailTemplateContentBuilder.kt
@@ -1,0 +1,12 @@
+package com.timeular.nytta.email.core
+
+import org.thymeleaf.ITemplateEngine
+import org.thymeleaf.context.Context
+import java.util.*
+
+open class MailTemplateContentBuilder(
+        private val mailTemplateEngine: ITemplateEngine
+) {
+    fun build(template: String, context: Map<String, Any>): String =
+            mailTemplateEngine.process(template, Context(Locale.ENGLISH, context))
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailgunMailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/MailgunMailService.kt
@@ -1,0 +1,111 @@
+package com.timeular.nytta.email.core
+
+import com.google.common.base.Preconditions.checkNotNull
+import com.google.gson.JsonParser
+import okhttp3.Credentials
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.slf4j.LoggerFactory
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+
+open class MailgunMailService(
+        mailTemplateContentBuilder: MailTemplateContentBuilder,
+        private val mailServiceHelper: MailServiceHelper,
+        private val baseUrl: String,
+        apiKey: String,
+        private val domain: String
+) : AbstractMailService(mailTemplateContentBuilder, mailServiceHelper) {
+
+    private val okHttpClient: okhttp3.OkHttpClient
+    private val jsonParser = JsonParser()
+
+    init {
+        checkNotNull(baseUrl, "You have to provide a valid base url - pls look at the mailgun site to find it.")
+        checkNotNull(domain, "You have to provide a mailgun domain")
+        checkNotNull(apiKey, "You have to provide the mailgun api key")
+
+        val credential = Credentials.basic("api", apiKey)
+
+        okHttpClient = okhttp3.OkHttpClient.Builder()
+                .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
+                .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
+                .readTimeout(TIMEOUT, TimeUnit.SECONDS)
+                .addInterceptor { chain ->
+                    val request = chain.request().newBuilder()
+                            .header("Authorization", credential)
+                            .build()
+                    chain.proceed(request)
+                }
+                .build()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(MailgunMailService::class.java)
+        private const val TIMEOUT = 60L
+    }
+
+    override fun sendMail(mailConfig: MailConfig): Boolean {
+        val mailCfg = mailServiceHelper.modifyMailConfigForOverride(mailConfig)
+        val body = createMultipartBody(mailCfg)
+        val requestBuilder = Request.Builder()
+                .url("$baseUrl$domain/messages")
+                .post(body)
+
+        okHttpClient.newCall(requestBuilder.build()).execute().use { response ->
+            if (!response.isSuccessful) {
+                val responseBody = jsonParser.parse(response.body()?.string() ?: "")
+                logger.info(
+                        "Unable to send email ({}): http status: {} - {}",
+                        mailCfg.to,
+                        response.code(),
+                        responseBody?.asJsonObject?.get("message")?.asString ?: ""
+                )
+            }
+
+            return response.isSuccessful
+        }
+    }
+
+    private fun createMultipartBody(mailConfig: MailConfig): MultipartBody {
+        val contentBuilder = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("from", mailConfig.from.toString())
+                .addFormDataPart("subject", mailConfig.subject)
+
+        addAllContactToBuilder(contentBuilder, "to", mailConfig.to)
+        addAllContactToBuilder(contentBuilder, "cc", mailConfig.cc)
+        addAllContactToBuilder(contentBuilder, "bcc", mailConfig.bcc)
+
+        if (mailConfig.text.isNotBlank()) {
+            contentBuilder.addFormDataPart("text", mailConfig.text)
+        }
+
+        if (mailConfig.html.isNotBlank()) {
+            contentBuilder.addFormDataPart("html", mailConfig.html)
+        }
+
+        mailConfig.deliveryTime?.let {
+            val formattedDate = it.format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+            contentBuilder.addFormDataPart("o:deliverytime", formattedDate)
+                    .addFormDataPart("h:Date", formattedDate)
+        }
+
+        mailConfig.tag?.let {
+            contentBuilder.addFormDataPart("o:tag", it)
+        }
+
+        mailConfig.inlineAttachments.forEach {
+            val content = it.resource
+            contentBuilder.addFormDataPart("inline", it.name, RequestBody.create(MediaType.parse(it.mimeType), content))
+        }
+
+        return contentBuilder.build()
+    }
+
+    private fun addAllContactToBuilder(contentBuilder: MultipartBody.Builder, field: String, contacts: List<MailContact>) =
+            contacts.forEach { contentBuilder.addFormDataPart(field, it.toString()) }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/SendAndPersistMailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/SendAndPersistMailService.kt
@@ -1,0 +1,37 @@
+package com.timeular.nytta.email.core
+
+import java.time.ZonedDateTime
+
+open class SendAndPersistMailService(
+        private val dbPersistentMailService: DbPersistentMailService,
+        private val mailgunMailService: MailgunMailService,
+        private val persistMails: Boolean,
+        private val sendMails: Boolean
+) : MailService {
+    override fun sendMail(mailConfig: MailConfig): Boolean {
+        var result = false
+        if (sendMails) {
+            result = mailgunMailService.sendMail(mailConfig)
+        }
+
+        if (persistMails) {
+            result = result.xor(sendMails).not() && dbPersistentMailService.sendMail(mailConfig)
+        }
+
+        return result
+    }
+
+    override fun sendMail(mailTemplate: MailTemplate, mailContext: Map<String, Any>, receiver: Set<MailContact>,
+                          deliveryTime: ZonedDateTime?, inlineAttachments: List<Attachment>): Boolean {
+        var result = false
+        if (sendMails) {
+            result = mailgunMailService.sendMail(mailTemplate, mailContext, receiver, deliveryTime, inlineAttachments)
+        }
+
+        if (persistMails) {
+            result = result.xor(sendMails).not() && dbPersistentMailService.sendMail(mailTemplate, mailContext, receiver, deliveryTime)
+        }
+
+        return result
+    }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/StringMailService.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/StringMailService.kt
@@ -1,0 +1,49 @@
+package com.timeular.nytta.email.core
+
+import java.time.ZonedDateTime
+import java.util.*
+import kotlin.collections.HashMap
+
+/**
+ * this mail service is only for generating mails and saving the outcome in an thread safe variable
+ */
+class StringMailService(
+        mailTemplateContentBuilder: MailTemplateContentBuilder,
+        mailServiceHelper: MailServiceHelper
+) : AbstractMailService(mailTemplateContentBuilder, mailServiceHelper) {
+
+    val mailConfig = ThreadLocal<MailConfig>()
+
+    override fun sendMail(
+            mailTemplate: MailTemplate,
+            mailContext: Map<String, Any>,
+            receiver: Set<MailContact>,
+            deliveryTime: ZonedDateTime?,
+            inlineAttachments: List<Attachment>
+    ): Boolean {
+
+        val enhancedMailContext = HashMap<String, Any>(mailContext)
+
+        inlineAttachments.forEach {
+            enhancedMailContext[it.name.replace(".", "")] = createDataUrl(it)
+        }
+
+        mailTemplate.mailConfigBuilder.inlineAttachments.forEach {
+            enhancedMailContext[it.name.replace(".", "")] = createDataUrl(it)
+        }
+
+        return super.sendMail(mailTemplate, enhancedMailContext, receiver, deliveryTime, inlineAttachments)
+    }
+
+    override fun sendMail(mailConfig: MailConfig): Boolean {
+        this.mailConfig.set(mailConfig)
+        return true
+    }
+
+    private fun createDataUrl(attachment: Attachment): String {
+        val content = attachment.resource
+        val base64Img = Base64.getEncoder().encode(content).toString(Charsets.UTF_8)
+
+        return "data:${attachment.mimeType};base64,$base64Img"
+    }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/db/MailPreparedStatmentHelper.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/db/MailPreparedStatmentHelper.kt
@@ -1,0 +1,61 @@
+package com.timeular.nytta.email.core.db
+
+import com.google.common.base.Joiner
+import com.timeular.nytta.email.core.Attachment
+import com.timeular.nytta.email.core.MailConfig
+import java.sql.Connection
+import java.sql.Date
+import java.sql.PreparedStatement
+import java.sql.Statement
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+const val MAIL_STORAGE_NAME = "mail_storage"
+const val MAIL_STORAGE_ATTACHMENT_NAME = "mail_storage_attachment"
+
+class InsertMailPreparedStatementCreator(
+        private val joiner: Joiner,
+        private val mailConfig: MailConfig
+) {
+
+    companion object {
+        private const val MAIL_STORAGE_INSERT = """INSERT INTO $MAIL_STORAGE_NAME(
+            sender, subject, receiver, cc, bcc, rawText, html, deliveryTime, tag)
+            VALUES (?, ?, ?, ?, ?, ? , ?, ? , ?)"""
+    }
+
+    fun createPreparedStatement(con: Connection?): PreparedStatement {
+        val stmt = con!!.prepareStatement(MAIL_STORAGE_INSERT, Statement.RETURN_GENERATED_KEYS)
+
+        stmt.setString(1, mailConfig.from.toString())
+        stmt.setString(2, mailConfig.subject)
+        stmt.setString(3, joiner.join(mailConfig.to.map { it.toString() }))
+        stmt.setString(4, joiner.join(mailConfig.cc.map { it.toString() }))
+        stmt.setString(5, joiner.join(mailConfig.bcc.map { it.toString() }))
+        stmt.setString(6, mailConfig.text)
+        stmt.setString(7, mailConfig.html)
+        stmt.setDate(8, mailConfig.deliveryTime?.toSqlDate())
+        stmt.setString(9, mailConfig.tag)
+
+        return stmt
+    }
+
+    private fun ZonedDateTime.toSqlDate(): Date =
+            Date(this.withZoneSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli())
+}
+
+class MailAttachmentParameterizedPreparedStatementSetter(
+        private val mailId: Long
+) {
+
+    fun setValues(ps: PreparedStatement, attachment: Attachment) {
+        ps.setLong(1, mailId)
+        ps.setString(2, attachment.name)
+        ps.setString(3, attachment.mimeType)
+
+        attachment.resource.inputStream().use {
+            ps.setBinaryStream(4, it)
+        }
+        ps.addBatch()
+    }
+}

--- a/email/core/src/main/kotlin/com/timeular/nytta/email/core/db/MailStorageRepository.kt
+++ b/email/core/src/main/kotlin/com/timeular/nytta/email/core/db/MailStorageRepository.kt
@@ -1,0 +1,72 @@
+package com.timeular.nytta.email.core.db
+
+import com.google.common.base.Joiner
+import com.timeular.nytta.email.core.MailConfig
+import com.timeular.nytta.email.core.MailException
+import javax.sql.DataSource
+
+open class MailStorageRepository(
+        private val dataSource: DataSource
+) {
+    private val joiner = Joiner.on(",")
+
+    companion object {
+        private const val MAIL_STORAGE_ATTACHMENT_INSERT = """INSERT INTO $MAIL_STORAGE_ATTACHMENT_NAME(
+            mail_Id, name, mime_type, data)
+            VALUES (?, ?, ?, ?)"""
+    }
+
+    fun saveMailConfig(mailConfig: MailConfig): Boolean {
+        val con = dataSource.connection
+        val stmt = InsertMailPreparedStatementCreator(joiner, mailConfig).createPreparedStatement(con)
+        val attrStmt = con.prepareStatement(MAIL_STORAGE_ATTACHMENT_INSERT)
+        try {
+            var result = stmt.executeUpdate() == 1
+            return if (result && mailConfig.inlineAttachments.isNotEmpty()) {
+                var mailId = -1L
+                val generatedKeys = stmt.generatedKeys
+                if (generatedKeys.next()) {
+                    mailId =  generatedKeys.getLong("ID")
+                }
+                con.commit()
+
+                if (mailId > 0) {
+                    val mailAttachmentParameterizedPreparedStatementSetter = MailAttachmentParameterizedPreparedStatementSetter(mailId)
+                    mailConfig.inlineAttachments.forEach {
+                        mailAttachmentParameterizedPreparedStatementSetter.setValues(attrStmt, it)
+                    }
+                    val attResult = attrStmt.executeBatch()
+                    con.commit()
+
+                    attResult.forEach {amountOfResults ->
+                        result = result && amountOfResults == 1
+                    }
+                } else {
+                    throw MailException("Unable to save mail attachments - unable to fetch id of stored mail")
+                }
+                        stmt.close()
+                result
+            } else {
+                result
+            }
+        } finally {
+            attrStmt.close()
+            stmt.close()
+        }
+    }
+
+    fun deleteAllMails() {
+        val con = dataSource.connection
+        val attachmentStmt = con.prepareStatement("delete from $MAIL_STORAGE_ATTACHMENT_NAME")
+        val mailStmt = con.prepareStatement("delete from $MAIL_STORAGE_NAME")
+        try {
+            attachmentStmt.executeUpdate()
+            mailStmt.executeUpdate()
+            con.commit()
+        } finally {
+            attachmentStmt.close()
+            mailStmt.close()
+        }
+    }
+}
+

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/DBUnitTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/DBUnitTest.kt
@@ -1,0 +1,101 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
+import org.dbunit.DataSourceDatabaseTester
+import org.dbunit.IDatabaseTester
+import org.dbunit.IOperationListener
+import org.dbunit.database.DatabaseConfig
+import org.dbunit.database.IDatabaseConnection
+import org.dbunit.dataset.ITable
+import org.dbunit.dataset.xml.FlatXmlDataSetBuilder
+import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory
+import org.dbunit.operation.DatabaseOperation
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+import java.math.BigInteger
+import javax.sql.DataSource
+
+abstract class DBUnitTest {
+    val testDataSource: DataSource = initializeDataSource()
+
+    private var databaseTester: IDatabaseTester = initializeDatabaseTester()
+
+    @BeforeEach
+    open fun before() {
+        databaseTester.onSetup()
+    }
+
+    private fun initializeDataSource(): JdbcDataSource {
+        val ds = JdbcDataSource()
+        ds.setURL("jdbc:h2:~/sample")
+        ds.user = "sa"
+        ds.password = ""
+        return ds
+    }
+
+    private fun initializeDatabaseTester(): IDatabaseTester {
+        val tablesSQL = File(ClassLoader.getSystemResource("db/mail_storage.sql").file).readText()
+        val con = testDataSource.connection
+        val stmt = con.prepareStatement(tablesSQL)
+        try {
+            stmt.executeUpdate()
+        } catch (e: Exception) {
+            // if tables are already created, ignore
+        } finally {
+            stmt.close()
+        }
+        
+        val dbTester = DataSourceDatabaseTester(testDataSource)
+
+        val dataSet = FlatXmlDataSetBuilder().build(
+                DBUnitTest::class.java.getResourceAsStream("/db/test-data.xml"))
+
+        dbTester.dataSet = dataSet
+        dbTester.setUpOperation = DatabaseOperation.CLEAN_INSERT
+        dbTester.setOperationListener(OperationListener())
+
+        return dbTester
+    }
+
+    protected fun connection(): IDatabaseConnection = databaseTester.connection
+
+    protected fun assertColumnInFirstRow(table: ITable, columnName: String, expectedValue: String?) {
+        assertThat(table.getValue(0, columnName) as String?, equalTo(expectedValue))
+    }
+
+    protected fun assertColumnInFirstRow(table: ITable, columnName: String, expectedValue: BigInteger) {
+        assertThat(table.getValue(0, columnName) as BigInteger, equalTo(expectedValue))
+    }
+
+    protected fun assertColumnInFirstRow(table: ITable, columnName: String, expectedValue: Boolean) {
+        assertThat(table.getValue(0, columnName) as Boolean, equalTo(expectedValue))
+    }
+
+    protected fun assertColumnInFirstRowPresent(table: ITable, columnName: String, expectedValue: Any?) {
+        if (expectedValue != null) {
+            assertThat(table.getValue(0, columnName), present())
+        } else {
+            assertThat(table.getValue(0, columnName), absent())
+        }
+    }
+}
+
+class OperationListener : IOperationListener {
+    private val postgresqlDataTypeFactory = PostgresqlDataTypeFactory()
+
+    override fun operationSetUpFinished(connection: IDatabaseConnection?) {
+
+    }
+
+    override fun operationTearDownFinished(connection: IDatabaseConnection?) {
+
+    }
+
+    override fun connectionRetrieved(connection: IDatabaseConnection?) {
+        connection?.config?.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, postgresqlDataTypeFactory)
+    }
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailConfigTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailConfigTest.kt
@@ -1,0 +1,111 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.hasSize
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class MailConfigTest {
+
+    private lateinit var builder: MailConfig.Builder
+
+    @BeforeEach
+    fun beforeEach() {
+        builder = MailConfig.Builder()
+    }
+
+    @Test
+    fun testBuilderWithNoAttributes() {
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+    }
+
+    @Test
+    fun testBuilderWithSubjectOnly() {
+        builder.from("test@me.com").subject("test")
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+    }
+
+    @Test
+    fun testBuilderWithMissingFromOnly() {
+        builder.from("test@me.com")
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+    }
+
+    @Test
+    fun testBuilderWithMissingReceiver() {
+        builder.from("test@me.com").subject("Test")
+                .text("text")
+
+        // missing to, cc, bcc
+        builder.clearTo()
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+
+        // test To
+        builder.addTo("test@me.com")
+        builder.build()
+        builder.clearTo()
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+
+        // test cc
+        builder.addCC("test@me.com")
+        builder.build()
+        builder.clearCC()
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+
+        // test bcc
+        builder.addBCC("test@me.com")
+        builder.build()
+        builder.clearBCC()
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+    }
+
+    @Test
+    fun testBuilderWithMissingContent() {
+        builder.from("test@me.com")
+                .subject("test")
+                .addTo("receiver@me.com")
+
+        //missing text & html
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+
+        // test text
+        builder.text("text")
+        builder.build()
+        builder.text("")
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+
+        // test html
+        builder.html("html")
+        builder.build()
+        builder.html("")
+        assertThrows(MailConfigurationException::class.java) { builder.build() }
+    }
+
+    @Test
+    fun testMailConfig() {
+        val cfg = builder.from("support@timeular.com", "Timeular Support Team")
+                .subject("Test Message")
+                .text("If everything seems to be going well, you have obviously overlooked something.")
+                .html("Matter will be damaged in direct proportion to its value.")
+                .addTo("first@test.com")
+                .addCC("cc@test.com")
+                .addBCC("bcc@test.com")
+                .build()
+
+        assertThat(cfg.text, equalTo("If everything seems to be going well, you have obviously overlooked something."))
+        assertThat(cfg.html, equalTo("Matter will be damaged in direct proportion to its value."))
+        assertThat(cfg.subject, equalTo("Test Message"))
+        assertThat(cfg.from.toString(), equalTo("Timeular Support Team <support@timeular.com>"))
+
+        assertThat(cfg.to, hasSize(equalTo(1)))
+        assertThat(cfg.to[0].toString(), equalTo("first@test.com"))
+
+        assertThat(cfg.cc, hasSize(equalTo(1)))
+        assertThat(cfg.cc[0].toString(), equalTo("cc@test.com"))
+
+        assertThat(cfg.bcc, hasSize(equalTo(1)))
+        assertThat(cfg.bcc[0].toString(), equalTo("bcc@test.com"))
+    }
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailContactTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailContactTest.kt
@@ -1,0 +1,21 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+internal class MailContactTest{
+
+    @Test
+    fun testCreateMailContract(){
+        val contact = MailContact("test@me.com")
+        assertThat(contact.email, equalTo("test@me.com"))
+    }
+
+    @Test
+    fun testToString(){
+        assertThat(MailContact("test@me.com").toString(), equalTo("test@me.com"))
+        assertThat(MailContact("test@me.com", "Hallo du").toString(), equalTo("Hallo du <test@me.com>"))
+    }
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailServiceHelperTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailServiceHelperTest.kt
@@ -1,0 +1,154 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.sameInstance
+import org.junit.jupiter.api.Test
+
+internal class MailServiceHelperTest {
+
+    companion object {
+        private const val MAIL_TO_ADDRESS = "test@timeular.com"
+    }
+
+    @Test
+    fun testModifyTemplateContextForOverride() {
+        var helper = MailServiceHelper(false, MAIL_TO_ADDRESS)
+
+        val builder = MailConfig.Builder()
+                .subject("Blub")
+                .html("blab")
+                .addBCC("test@mail.com")
+                .addBCC("test2@gmail.com")
+                .addTo("another@mail.com")
+
+        val ctx: Map<String, Any> = HashMap()
+
+        var result = helper.modifyTemplateContextForOverride(ctx, builder)
+        assertThat(result, sameInstance(ctx))
+
+        helper = MailServiceHelper(true, MAIL_TO_ADDRESS)
+        result = helper.modifyTemplateContextForOverride(ctx, builder)
+
+        assertThat(result.size, equalTo(4))
+        assertThat(result["overrideAddress"] as String?, equalTo(MAIL_TO_ADDRESS))
+        assertThat(result["originalAddressTo"] as String?, equalTo("another@mail.com"))
+        assertThat(result["originalAddressCC"] as String?, equalTo(""))
+        assertThat(result["originalAddressBcc"] as String?, equalTo("test@mail.com,test2@gmail.com"))
+    }
+
+    @Test
+    fun testModifyMailConfigBuilderForOverride() {
+        var helper = MailServiceHelper(false, MAIL_TO_ADDRESS)
+
+        val builder = MailConfig.Builder()
+                .subject("Blub")
+                .html("blab")
+                .addBCC("test@mail.com")
+                .addBCC("test2@gmail.com")
+                .addTo("another@mail.com")
+
+        var result = helper.modifyMailConfigBuilderForOverride(builder)
+        assertThat(result, sameInstance(builder))
+
+        helper = MailServiceHelper(true, MAIL_TO_ADDRESS)
+        result = helper.modifyMailConfigBuilderForOverride(builder)
+
+        assertThat(result.bcc.isEmpty(), equalTo(true))
+        assertThat(result.cc.isEmpty(), equalTo(true))
+        assertThat(result.to.size, equalTo(1))
+        assertThat(result.to[0].email, equalTo(MAIL_TO_ADDRESS))
+    }
+
+    @Test
+    fun testModifyMailConfigForOverride() {
+        var helper = MailServiceHelper(false, MAIL_TO_ADDRESS)
+
+        val mailCfg = MailConfig.Builder()
+                .subject("Blub")
+                .html("blab")
+                .from("support@timeular.com")
+                .addBCC("test@mail.com")
+                .addBCC("test2@gmail.com")
+                .addTo("another@mail.com")
+                .build()
+
+        var result = helper.modifyMailConfigForOverride(mailCfg)
+        assertThat(result, sameInstance(mailCfg))
+
+        helper = MailServiceHelper(true, MAIL_TO_ADDRESS)
+        result = helper.modifyMailConfigForOverride(mailCfg)
+
+        assertThat(result.bcc.isEmpty(), equalTo(true))
+        assertThat(result.cc.isEmpty(), equalTo(true))
+        assertThat(result.to.size, equalTo(1))
+        assertThat(result.to[0].email, equalTo(MAIL_TO_ADDRESS))
+    }
+
+    @Test
+    fun testNeedToModifyMailConfigBuilder() {
+        var helper = MailServiceHelper(false, MAIL_TO_ADDRESS)
+        val builder = MailConfig.Builder()
+                .subject("Blub")
+                .html("blab")
+                .addBCC("test@mail.com")
+
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(false))
+
+        helper = MailServiceHelper(true, MAIL_TO_ADDRESS)
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(true))
+
+        builder.clearBCC()
+        builder.addCC("test@mail.com")
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(true))
+        builder.clearCC()
+        builder.addTo("test@mail.com")
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(true))
+
+        builder.clearTo()
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(true))
+
+        builder.addTo(MAIL_TO_ADDRESS)
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(false))
+
+        builder.addCC("test@mailc.om")
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(true))
+
+        builder.clearCC()
+        builder.addBCC("test@mailc.om")
+        assertThat(helper.needToModifyMailConfigBuilder(builder), equalTo(true))
+    }
+
+    @Test
+    fun testNeedToModifyMailConfig() {
+        var helper = MailServiceHelper(false, MAIL_TO_ADDRESS)
+        val builder = MailConfig.Builder()
+                .subject("Blub")
+                .from("support@timeular.com")
+                .html("blab")
+                .addBCC("test@mail.com")
+
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(false))
+
+        helper = MailServiceHelper(true, MAIL_TO_ADDRESS)
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(true))
+
+        builder.clearBCC()
+        builder.addCC("test@mail.com")
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(true))
+        builder.clearCC()
+        builder.addTo("test@mail.com")
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(true))
+
+        builder.clearTo()
+        builder.addTo(MAIL_TO_ADDRESS)
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(false))
+
+        builder.addCC("test@mailc.om")
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(true))
+
+        builder.clearCC()
+        builder.addBCC("test@mailc.om")
+        assertThat(helper.needToModifyMailConfig(builder.build()), equalTo(true))
+    }
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailTemplateContentBuilderTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailTemplateContentBuilderTest.kt
@@ -1,0 +1,48 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+data class User(
+        val firstName: String
+)
+
+internal class MailTemplateContentBuilderTest(
+
+) {
+    private val mailTemplateContentBuilder = MailTemplateContentBuilder(
+            mailTemplateEngine = templateEngine()
+    )
+
+    @Test
+    fun testBuild() {
+        val ctx = mapOf<String, Any>("user" to createWeeklyUser())
+
+        assertThat(
+                mailTemplateContentBuilder.build("test_template.txt", ctx),
+                equalTo("Wow a text template for Johann!!")
+        )
+
+        assertThat(
+                mailTemplateContentBuilder.build("test_template.html", ctx),
+                equalTo("""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sample Template</title>
+</head>
+<body>
+
+<h1>Hi there <span>Johann</span></h1>
+
+</body>
+</html>""")
+        )
+    }
+
+    private fun createWeeklyUser() =
+            User(
+                    firstName = "Johann"
+            )
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailgunMailServiceTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/MailgunMailServiceTest.kt
@@ -1,0 +1,63 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.timeular.nytta.email.*
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+internal class MailgunMailServiceTest {
+    private val mailgunMailService = MailgunMailService(
+            mailTemplateContentBuilder = MailTemplateContentBuilder(
+                    mailTemplateEngine = templateEngine()
+            ),
+            mailServiceHelper = MailServiceHelper(),
+            baseUrl = "set-if-you-want-to-test",
+            apiKey = "set-if-you-want-to-test",
+            domain = "set-if-you-want-to-test"
+    )
+
+    private val tmpl = MailTemplate(
+            mailConfigBuilder = MailConfig.Builder(),
+            htmlTemplate = "test_template.html",
+            txtTemplate = "test_template.txt"
+    )
+
+    @Test
+    @Disabled
+    fun testSendMail() {
+        val cfg = MailConfig.Builder()
+                .from("support@timeular.com", "Support")
+                .subject("Test Email from Code")
+                .text("Yeah! Emails are sending!")
+                .addTo("sp@timeular.com")
+                .deliveryTime(ZonedDateTime.parse("2018-08-13T22:10:00+02:00"))
+                .tag("unitTest")
+                .build()
+
+        assertThat(
+                mailgunMailService.sendMail(
+                        mailConfig = cfg
+                ),
+                equalTo(true)
+        )
+    }
+
+    @Test
+    @Disabled
+    fun testSendMailFromTemplate() {
+        val ctx = HashMap<String, Any>()
+        ctx["user"] = "User"
+
+        assertThat(
+                mailgunMailService.sendMail(
+                        mailTemplate = tmpl,
+                        mailContext = ctx,
+                        receiver = setOf(MailContact("sp+test@timeular.com")),
+                        deliveryTime = ZonedDateTime.parse("2018-08-12T10:00:00+02:00")
+                ),
+                equalTo(true)
+        )
+    }
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/SendAndPersistMailServiceTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/SendAndPersistMailServiceTest.kt
@@ -1,0 +1,145 @@
+package com.timeular.nytta.email.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+internal class SendAndPersistMailServiceTest {
+
+    private val mailBuilder = MailConfig.Builder()
+            .subject("test")
+            .text("text")
+            .from("bla@test.com")
+            .addTo("test@test.com")
+
+    @Test
+    fun testSendMailWithConfig() {
+        doTestSendMailWithConfig(
+                sendMails = true,
+                returnSend = true,
+                persistMails = true,
+                returnPersist = true,
+                expectedResult = true
+        )
+
+        doTestSendMailWithConfig(
+                sendMails = false,
+                persistMails = true,
+                returnPersist = true,
+                expectedResult = true
+        )
+
+        doTestSendMailWithConfig(
+                sendMails = false,
+                persistMails = false,
+                expectedResult = false
+        )
+    }
+
+    @Test
+    fun testSendMailWithTemplate() {
+        doTestSendMailWithTemplate(
+                sendMails = true,
+                returnSend = true,
+                persistMails = true,
+                returnPersist = true,
+                expectedResult = true
+        )
+
+        doTestSendMailWithTemplate(
+                sendMails = false,
+                persistMails = true,
+                returnPersist = true,
+                expectedResult = true
+        )
+
+        doTestSendMailWithTemplate(
+                sendMails = false,
+                persistMails = false,
+                expectedResult = false
+        )
+    }
+
+    private fun doTestSendMailWithConfig(
+            persistMails: Boolean,
+            sendMails: Boolean,
+            returnPersist: Boolean = false,
+            returnSend: Boolean = false,
+            expectedResult: Boolean
+    ) {
+        assertThat(createMailService(
+                persistMails = persistMails,
+                sendMails = sendMails,
+                returnPersist = returnPersist,
+                returnSend = returnSend
+        ).sendMail(mailBuilder.build()),
+                equalTo(expectedResult)
+        )
+    }
+
+    private fun doTestSendMailWithTemplate(
+            persistMails: Boolean,
+            sendMails: Boolean,
+            returnPersist: Boolean = false,
+            returnSend: Boolean = false,
+            expectedResult: Boolean
+    ) {
+        assertThat(createMailService(
+                persistMails = persistMails,
+                sendMails = sendMails,
+                returnPersist = returnPersist,
+                returnSend = returnSend
+        ).sendMail(
+                mailTemplate = MailTemplate(
+                        mailConfigBuilder = mailBuilder,
+                        htmlTemplate = "",
+                        txtTemplate = ""
+                ),
+                mailContext = HashMap(),
+                receiver = HashSet()
+        ),
+                equalTo(expectedResult)
+        )
+    }
+
+    private fun createMailService(
+            persistMails: Boolean,
+            sendMails: Boolean,
+            returnPersist: Boolean,
+            returnSend: Boolean
+    ) =
+            SendAndPersistMailService(
+                    dbPersistentMailService = MockDbPersistentMailService(returnPersist),
+                    mailgunMailService = MockMailGunMailService(returnSend),
+                    persistMails = persistMails,
+                    sendMails = sendMails
+            )
+}
+
+open class MockDbPersistentMailService(
+        val returnValue: Boolean
+) : DbPersistentMailService(
+        mailTemplateContentBuilder = mock(),
+        mailStorageRepository = mock(),
+        mailServiceHelper = mock()
+) {
+    override fun sendMail(mailConfig: MailConfig): Boolean = returnValue
+
+    override fun sendMail(mailTemplate: MailTemplate, mailContext: Map<String, Any>, receiver: Set<MailContact>, deliveryTime: ZonedDateTime?, inlineAttachments: List<Attachment>): Boolean = returnValue
+}
+
+open class MockMailGunMailService(
+        val returnValue: Boolean
+) : MailgunMailService(
+        mailTemplateContentBuilder = mock(),
+        mailServiceHelper = mock(),
+        apiKey = "",
+        baseUrl = "",
+        domain = ""
+) {
+    override fun sendMail(mailConfig: MailConfig): Boolean = returnValue
+
+    override fun sendMail(mailTemplate: MailTemplate, mailContext: Map<String, Any>, receiver: Set<MailContact>, deliveryTime: ZonedDateTime?, inlineAttachments: List<Attachment>): Boolean = returnValue
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/TestHelpers.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/TestHelpers.kt
@@ -1,0 +1,29 @@
+package com.timeular.nytta.email.core
+
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
+
+fun htmlTemplateResolver(): ClassLoaderTemplateResolver {
+    val resolver = ClassLoaderTemplateResolver()
+    resolver.prefix = "mail/templates/"
+    resolver.suffix = ".html"
+    resolver.templateMode = TemplateMode.HTML
+    resolver.isCacheable = true
+    return resolver
+}
+
+fun textTemplateResolver(): ClassLoaderTemplateResolver {
+    val resolver = ClassLoaderTemplateResolver()
+    resolver.prefix = "mail/templates/"
+    resolver.suffix = ".txt"
+    resolver.templateMode = TemplateMode.TEXT
+    resolver.isCacheable = true
+    return resolver
+}
+
+fun templateEngine(): TemplateEngine {
+    val engine = TemplateEngine()
+    engine.templateResolvers = setOf(htmlTemplateResolver(), textTemplateResolver())
+    return engine
+}

--- a/email/core/src/test/kotlin/com/timeular/nytta/email/core/db/MailStorageRepositoryTest.kt
+++ b/email/core/src/test/kotlin/com/timeular/nytta/email/core/db/MailStorageRepositoryTest.kt
@@ -1,0 +1,96 @@
+package com.timeular.nytta.email.core.db
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
+import com.timeular.nytta.email.core.DBUnitTest
+import com.timeular.nytta.email.core.MailConfig
+import org.dbunit.dataset.ITable
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class MailStorageRepositoryTest: DBUnitTest() {
+
+    private val mailStorageRepository = MailStorageRepository(testDataSource)
+
+    companion object {
+        private const val MAIL_STORAGE_NAME = "mail_storage"
+    }
+
+    private var mailBuilder = MailConfig.Builder()
+
+    @BeforeEach
+    fun beforeEach() {
+        mailBuilder = MailConfig.Builder()
+                .subject("test")
+                .text("text")
+                .from("bla@test.com")
+                .addTo("test@test.com")
+    }
+
+    @AfterEach
+    fun afterEach() {
+        mailStorageRepository.deleteAllMails()
+    }
+
+    @Test
+    fun testSaveMailConfig() {
+        mailStorageRepository.saveMailConfig(mailBuilder.build())
+        assertThat(connection().getRowCount(MAIL_STORAGE_NAME), equalTo(1))
+
+        val table = verifyTestMailTable()
+        val mailId = table.getValue(0, "id") as Int
+        assertThat(connection().getRowCount(MAIL_STORAGE_ATTACHMENT_NAME, "WHERE mail_id = $mailId"), equalTo(0))
+    }
+
+    @Test
+    fun testSaveMailConfigWithAttachments() {
+        mailBuilder.addInlineAttachment("test.txt", "text/plain", "text_test".toByteArray())
+        mailBuilder.addInlineAttachment("test.html", "text/html", "html_test".toByteArray())
+
+        mailStorageRepository.saveMailConfig(mailBuilder.build())
+        val table = verifyTestMailTable()
+
+        val mailId = table.getValue(0, "id") as Int
+
+        val attachmentTable = connection().createQueryTable(
+                MAIL_STORAGE_ATTACHMENT_NAME,
+                "SELECT * FROM $MAIL_STORAGE_ATTACHMENT_NAME WHERE mail_id=$mailId"
+        )
+
+        assertThat(attachmentTable.rowCount, equalTo(2))
+        assertColumnInFirstRow(attachmentTable, "name", "test.txt")
+        assertColumnInFirstRow(attachmentTable, "mime_type", "text/plain")
+        assertThat(attachmentTable.getValue(0, "data"), present())
+    }
+
+    private fun verifyTestMailTable(): ITable {
+        assertThat(connection().getRowCount(MAIL_STORAGE_NAME), equalTo(1))
+        val table = connection().createQueryTable(MAIL_STORAGE_NAME, "SELECT * FROM $MAIL_STORAGE_NAME")
+
+        assertThat(table.rowCount, equalTo(1))
+        assertColumnInFirstRow(table, "sender", mailBuilder.build().from.toString())
+        assertColumnInFirstRow(table, "subject", mailBuilder.build().subject)
+        assertColumnInFirstRow(table, "receiver", "test@test.com")
+        assertColumnInFirstRow(table, "cc", "")
+        assertColumnInFirstRow(table, "bcc", "")
+        assertColumnInFirstRow(table, "rawText", mailBuilder.build().text)
+        assertColumnInFirstRow(table, "html", "")
+        assertColumnInFirstRow(table, "deliveryTime", null)
+        assertColumnInFirstRow(table, "tag", null)
+
+        return table
+    }
+
+    @Test
+    fun testDeleteAllMails() {
+        for (i in 1..10) {
+            mailStorageRepository.saveMailConfig(mailBuilder.build())
+        }
+        assertThat(connection().getRowCount(MAIL_STORAGE_NAME), equalTo(10))
+
+        mailStorageRepository.deleteAllMails()
+        assertThat(connection().getRowCount(MAIL_STORAGE_NAME), equalTo(0))
+    }
+}

--- a/email/core/src/test/resources/db/mail_storage.sql
+++ b/email/core/src/test/resources/db/mail_storage.sql
@@ -1,0 +1,28 @@
+CREATE TABLE mail_storage(
+  id            SERIAL        NOT NULL,
+  sender        VARCHAR(255)  NOT NULL,
+  subject       VARCHAR(255)  NOT NULL,
+  receiver      VARCHAR(255),
+  cc            VARCHAR(255),
+  bcc           VARCHAR(255),
+  rawText       TEXT,
+  html          TEXT,
+  deliveryTime  TIMESTAMP,
+  tag           VARCHAR(200),
+  creationTime  TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT mail_storage_pkey PRIMARY KEY (id)
+);
+
+
+CREATE TABLE mail_storage_attachment(
+  id            SERIAL        NOT NULL,
+  mail_Id       BIGINT        NOT NULL,
+  name          VARCHAR(255)  NOT NULL,
+  mime_type     VARCHAR(255)  NOT NULL,
+  data          BYTEA         NOT NULL,
+
+  CONSTRAINT mail_storage_attachment_pkey PRIMARY KEY (id),
+  CONSTRAINT mail_storage_attachment_mail_storage_fk FOREIGN KEY (mail_id)
+  REFERENCES mail_storage (id)
+);

--- a/email/core/src/test/resources/db/test-data.xml
+++ b/email/core/src/test/resources/db/test-data.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+</dataset>

--- a/email/core/src/test/resources/mail/templates/test_template.html
+++ b/email/core/src/test/resources/mail/templates/test_template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sample Template</title>
+</head>
+<body>
+
+<h1>Hi there <span th:text="${user.firstName}">Hans</span></h1>
+
+</body>
+</html>

--- a/email/core/src/test/resources/mail/templates/test_template.txt
+++ b/email/core/src/test/resources/mail/templates/test_template.txt
@@ -1,0 +1,1 @@
+Wow a text template for [(${user.firstName})]!!

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.timeular.nytta</groupId>
+        <artifactId>parent</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.timeular.nytta.email</groupId>
+    <artifactId>email-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Timeular Nytta Email</name>
+    <description>This module provides basic infrastructure for sending email</description>
+    <url>https://github.com/Timeular/nytta/email</url>
+
+    <modules>
+        <module>core</module>
+        <module>spring</module>
+    </modules>
+</project>

--- a/email/spring/.gitignore
+++ b/email/spring/.gitignore
@@ -5,15 +5,9 @@
 /classes/
 /gradle/
 
-# Maven
-target
-release.properties
-pom.xml.releaseBackup
-
 # IntelliJ IDEA project configuration
-*.iml
-*/.idea/*
-.idea/*
+/*.iml
+/.idea/*
 
 # macOS
 .DS_Store

--- a/email/spring/README.md
+++ b/email/spring/README.md
@@ -1,0 +1,151 @@
+# Nytta spring-email
+
+The Nytta spring-email module provides spring configuration for the [nytta email](https://github.com/Timeular/nytta/tree/master/email) module.
+
+## Latest release
+
+Coming soon.
+
+## Usage
+
+You can use this configuration by importing it into your Spring project, e.g.:
+
+```kotlin
+import com.timeular.nytta.email.spring.SpringMailConfiguration
+
+@Import(
+        SpringMailConfiguration::class
+)
+class MyApplication
+
+```
+
+### Configuration
+
+In order to configure the different components of the email module, you can simply create and register the beans you need.
+
+Full configuration example:
+
+The `MailgunMailService`, `DbPersistentMailService` and the `SendAndPersistMailService`, which send the email
+via `mailgun` and persist 
+
+```kotlin
+@Configuration
+@ComponentScan
+class MailConfiguration {
+    @Bean
+    fun mailStorageRepository(
+            dataSource: DataSource
+    ): MailStorageRepository = MailStorageRepository(dataSource)
+
+    @Bean
+    fun dbPersistentMailService(
+            mailTemplateContentBuilder: MailTemplateContentBuilder,
+            mailStorageRepository: MailStorageRepository,
+            mailServiceHelper: MailServiceHelper
+    ): DbPersistentMailService = DbPersistentMailService(
+                mailTemplateContentBuilder,
+                mailStorageRepository,
+                mailServiceHelper
+        )
+
+    @Bean
+    fun mailgunMailService(
+            mailTemplateContentBuilder: MailTemplateContentBuilder,
+            mailServiceHelper: MailServiceHelper,
+            @Value("\${mail.mailgun.base-url}")
+            baseUrl: String,
+            @Value("\${mail.mailgun.domain}")
+            apiKey: String,
+            @Value("\${mail.mailgun.api-key}")
+            domain: String
+    ): MailgunMailService = MailgunMailService(
+            mailTemplateContentBuilder,
+            mailServiceHelper,
+            baseUrl,
+            apiKey,
+            domain
+    )
+
+    @Bean
+    fun sendAndPersistMailService(
+            dbPersistentMailService: DbPersistentMailService,
+            mailgunMailService: MailgunMailService,
+            @Value("\${mail.persistence.enabled}")
+            persistMails: Boolean,
+            @Value("\${mail.delivery.enabled}")
+            sendMails: Boolean
+    ): SendAndPersistMailService = SendAndPersistMailService(
+            dbPersistentMailService,
+            mailgunMailService,
+            persistMails,
+            sendMails
+    )
+```
+The `StringMailService`, which returns a stringified version of an email
+
+```kotlin
+    @Bean
+    fun stringMailService(
+            mailTemplateContentBuilder: MailTemplateContentBuilder,
+            mailServiceHelper: MailServiceHelper
+    ): StringMailService = StringMailService(
+            mailTemplateContentBuilder,
+            mailServiceHelper
+    )
+```
+A custom email template:
+
+```kotlin
+    @Bean
+    fun myMailTemplate(
+            @Value("\${mail.mymail.sender.address}")
+            senderAddress: String,
+            @Value("\${mail.mymail.sender.name}")
+            senderName: String,
+            @Value("\${mail.mymail.subject}")
+            subject: String
+    ): MailTemplate {
+        if (senderAddress.isBlank()) {
+            throw MailConfigurationException("You have to configure a sender address for your weekly insights mails")
+        }
+
+        if (subject.isBlank()) {
+            throw MailConfigurationException("The subject for the weekly insights mail is not allowed to be blank")
+        }
+
+        val mailConfigBuilder = MailConfig.Builder()
+                .from(senderAddress, senderName)
+                .subject(subject)
+                .tag("myMail")
+
+        return MailTemplate(
+                mailConfigBuilder = mailConfigBuilder,
+                htmlTemplate = "myMail.html",
+                txtTemplate = "myMail.txt"
+        )
+    }
+}
+```
+
+## Templates
+
+You need to use `thymeleaf` templates, which, by default, have to be located in `resources/mail/templates`.
+
+## Properties
+
+There are currently two properties you can use override the e-mail receiver globally (e.g. for testing):
+
+```properties
+mail.test.override.enabled = false
+mail.test.override.receiver = invalid@timeular.com
+
+```
+
+The values above are the default values.
+
+## License
+
+The nytta email module is released under version 2.0 of the [Apache License][].
+
+[Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/email/spring/pom.xml
+++ b/email/spring/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.timeular.nytta.email</groupId>
+        <artifactId>email-parent</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.timeular.nytta.email</groupId>
+    <artifactId>spring</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+
+    <name>Timeular Nytta Spring Email</name>
+    <description>This module provides spring configuration for the email package</description>
+    <url>https://github.com/Timeular/nytta/email/spring</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.timeular.nytta.email</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.1.5.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf-spring5</artifactId>
+            <version>3.0.11.RELEASE</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/email/spring/src/main/kotlin/com/timeular/nytta/email/spring/SpringMailConfiguration.kt
+++ b/email/spring/src/main/kotlin/com/timeular/nytta/email/spring/SpringMailConfiguration.kt
@@ -1,0 +1,66 @@
+package com.timeular.nytta.email.spring
+
+import com.timeular.nytta.email.core.MailServiceHelper
+import com.timeular.nytta.email.core.MailTemplateContentBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.spring5.SpringTemplateEngine
+import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.templateresolver.ITemplateResolver
+
+@Configuration
+open class SpringMailConfiguration {
+    @Bean
+    open fun mailTemplateContentBuilder(
+            mailTemplateEngine: TemplateEngine
+    ): MailTemplateContentBuilder = MailTemplateContentBuilder(mailTemplateEngine)
+
+    @Bean
+    open fun mailServiceHelper(
+            @Value("\${mail.test.override.enabled}")
+            isOverrideEnabled: Boolean,
+            @Value("\${mail.test.override.receiver}")
+            overrideAddressString: String
+    ): MailServiceHelper = MailServiceHelper(isOverrideEnabled, overrideAddressString)
+
+    @Bean
+    open fun htmlTemplateResolver(
+            applicationContext: ApplicationContext
+    ): ITemplateResolver {
+        val templateResolver = SpringResourceTemplateResolver()
+        templateResolver.setApplicationContext(applicationContext)
+        templateResolver.prefix = "classpath:/mail/templates/"
+        templateResolver.suffix = ".html"
+        templateResolver.templateMode = TemplateMode.HTML
+        templateResolver.isCacheable = true
+        return templateResolver
+    }
+
+    @Bean
+    open fun txtTemplateResolver(
+            applicationContext: ApplicationContext
+    ): ITemplateResolver {
+        val templateResolver = SpringResourceTemplateResolver()
+        templateResolver.setApplicationContext(applicationContext)
+        templateResolver.prefix = "classpath:/mail/templates/"
+        templateResolver.suffix = ".txt"
+        templateResolver.templateMode = TemplateMode.TEXT
+        templateResolver.isCacheable = true
+        return templateResolver
+    }
+
+    @Bean
+    open fun mailTemplateEngine(
+            htmlTemplateResolver: ITemplateResolver,
+            txtTemplateResolver: ITemplateResolver
+    ): SpringTemplateEngine {
+        val templateEngine = SpringTemplateEngine()
+        templateEngine.templateResolvers = setOf(htmlTemplateResolver, txtTemplateResolver)
+        templateEngine.enableSpringELCompiler = true
+        return templateEngine
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <module>http-client</module>
         <module>spring-ext</module>
         <module>tracking</module>
+        <module>email</module>
     </modules>
 
     <properties>
@@ -88,6 +89,16 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-reflect</artifactId>
                 <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>3.13.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This adds an e-mail module to `nytta`.

There is an `email` module with all the functionality and a `spring-email` one for the spring config